### PR TITLE
feat: Implement React-Admin compliant SDUI architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Flutterish Architecture: Server-Driven UI (SDUI)
+
+This document outlines the architecture for transforming `flutterish` into a React-Admin compliant, server-driven framework for Flutter.
+
+## 1. Overview
+
+The goal is to allow developers (or servers) to define the entire application structure and logic via a JSON configuration, which `flutterish` interprets to render the UI. This mimics the declarative nature of React-Admin but moves the composition to runtime (or server-side).
+
+## 2. Core Concepts
+
+### 2.1 Admin Shell
+The `Admin` widget is the entry point. It requires:
+- `dataProvider`: Fetches content data (users, posts, etc.).
+- `authProvider`: Handles authentication.
+- `schemaProvider`: Fetches the UI configuration (JSON).
+
+### 2.2 UI Schema (The Build API)
+The UI is defined by a JSON object.
+
+**Structure:**
+```json
+{
+  "title": "My Admin",
+  "layout": "Layout",
+  "resources": [
+    {
+      "name": "posts",
+      "list": {
+        "type": "List",
+        "props": { "title": "All Posts" },
+        "children": [
+          {
+            "type": "Datagrid",
+            "children": [
+              { "type": "TextField", "props": { "source": "id" } },
+              { "type": "TextField", "props": { "source": "title" } }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### 2.3 Component Registry
+A central registry maps string keys (e.g., "Datagrid", "TextField") to Flutter widget builders.
+`Map<String, Widget Function(Map<String, dynamic> props, List<Widget> children)>`
+
+### 2.4 Data Provider Interface
+Mirrors React-Admin's `dataProvider`:
+- `getList(resource, params)`
+- `getOne(resource, params)`
+- `update(resource, params)`
+- ...
+
+## 3. State Management (Riverpod)
+- **SchemaState**: Stores the current parsed UI configuration.
+- **ResourceState**: Stores the data for the current view (list or details).
+- **NavigationState**: Tracks the current route/resource.
+
+## 4. Directory Structure
+- `lib/src/core/`: Engine, Interfaces, Providers.
+- `lib/src/ui/`: The concrete implementation of components (Datagrid, List, etc.).
+- `lib/src/components/`: Reusable primitive widgets.

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,18 @@
+targets:
+  $default:
+    builders:
+      riverpod_generator:
+        options:
+          keep_alive: true
+      json_serializable:
+        options:
+          explicit_to_json: true
+    sources:
+      - lib/**
+      - test/**
+      - example/lib/**
+      - "!example/linux/**"
+      - "!example/windows/**"
+      - "!example/macos/**"
+      - "!example/ios/**"
+      - "!example/android/**"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,20 +1,125 @@
-import 'package:flutter/material.dart' hide StepState, StepperType;
-
-import 'pages/stepper_demo_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutterish/flutterish.dart';
 
 void main() {
-  runApp(const MainApp());
+  runApp(const MyApp());
 }
 
-class MainApp extends StatelessWidget {
-  const MainApp({super.key});
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutterish Demo',
-      theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
-      home: const StepperDemoPage(),
+    return FlutterishAdmin(
+      title: 'Demo Admin',
+      dataProvider: MockDataProvider(),
+      authProvider: MockAuthProvider(),
+      schemaProvider: MockSchemaProvider(),
     );
+  }
+}
+
+class MockDataProvider implements DataProvider {
+  final _data = <String, List<Map<String, dynamic>>>{
+    'posts': [
+      {'id': '1', 'title': 'Hello World', 'author': 'John Doe'},
+      {'id': '2', 'title': 'Flutter is awesome', 'author': 'Jane Smith'},
+      {'id': '3', 'title': 'Server Driven UI', 'author': 'Bob'},
+    ],
+    'users': [
+      {'id': '1', 'name': 'John Doe', 'email': 'john@example.com'},
+      {'id': '2', 'name': 'Jane Smith', 'email': 'jane@example.com'},
+    ]
+  };
+
+  @override
+  Future<Map<String, dynamic>> create(String resource, Map<String, dynamic> data) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> delete(String resource, String id) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<GetListResult> getList(String resource, {int page = 1, int perPage = 10, Map<String, dynamic>? filter, Map<String, dynamic>? sort}) async {
+    await Future.delayed(const Duration(milliseconds: 500)); // Simulate latency
+    final list = _data[resource] ?? [];
+    return GetListResult(data: list, total: list.length);
+  }
+
+  @override
+  Future<Map<String, dynamic>> getOne(String resource, String id) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, dynamic>> update(String resource, String id, Map<String, dynamic> data) async {
+    throw UnimplementedError();
+  }
+}
+
+class MockAuthProvider implements AuthProvider {
+  @override
+  Future<void> checkAuth() async {}
+
+  @override
+  Future<void> checkError(error) async {}
+
+  @override
+  Future<dynamic> getPermissions() async => {};
+
+  @override
+  Future<void> login(Map<String, dynamic> params) async {}
+
+  @override
+  Future<void> logout() async {}
+}
+
+class MockSchemaProvider implements SchemaProvider {
+  @override
+  Future<Map<String, dynamic>> getSchema() async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    return {
+      "title": "Flutterish Demo",
+      "layout": "Layout",
+      "resources": [
+        {
+          "name": "posts",
+          "list": {
+            "type": "List",
+            "props": {"title": "All Posts"},
+            "children": [
+              {
+                "type": "Datagrid",
+                "children": [
+                  {"type": "TextField", "props": {"source": "id"}},
+                  {"type": "TextField", "props": {"source": "title"}},
+                  {"type": "TextField", "props": {"source": "author"}},
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "users",
+          "list": {
+            "type": "List",
+            "props": {"title": "Users Directory"},
+            "children": [
+              {
+                "type": "Datagrid",
+                "children": [
+                  {"type": "TextField", "props": {"source": "id"}},
+                  {"type": "TextField", "props": {"source": "name", "label": "Full Name"}},
+                  {"type": "TextField", "props": {"source": "email"}},
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    };
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,16 +5,16 @@ packages:
     dependency: transitive
     description:
       name: accessibility_tools
-      sha256: "088cfe6d3520dbe86bb5259059c0d5f478fe113e09311023b0485e68879b34b2"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: c29732e423175a51e0a6ace7df1255f5d77812c7c7b7101d8ba0186a43d533aa
+      url: "https://pub.dev"
     source: hosted
-    version: "2.7.1"
+    version: "2.8.0"
   async:
     dependency: transitive
     description:
       name: async
       sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
   boolean_selector:
@@ -22,7 +22,7 @@ packages:
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   characters:
@@ -30,7 +30,7 @@ packages:
     description:
       name: characters
       sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   clock:
@@ -38,7 +38,7 @@ packages:
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   collection:
@@ -46,7 +46,7 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
   device_frame_plus:
@@ -54,7 +54,7 @@ packages:
     description:
       name: device_frame_plus
       sha256: ccc94abccd4d9f0a9f19ef239001b3a59896e678ad42601371d7065889f2bf78
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
   fake_async:
@@ -62,7 +62,7 @@ packages:
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   flutter:
@@ -75,9 +75,17 @@ packages:
     description:
       name: flutter_lints
       sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_riverpod:
+    dependency: transitive
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -95,20 +103,52 @@ packages:
       relative: true
     source: path
     version: "0.0.2"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.4"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   inspector:
     dependency: transitive
     description:
       name: inspector
       sha256: a01ea538b15947a9189835cc910041bab91aea3ad7c421684118aa1040189ded
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "805fa86df56383000f640384b282ce0cb8431f1a7a2396de92fb66186d8c57df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
       sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "11.0.2"
   leak_tracker_flutter_testing:
@@ -116,7 +156,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.10"
   leak_tracker_testing:
@@ -124,7 +164,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   lints:
@@ -132,7 +172,7 @@ packages:
     description:
       name: lints
       sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   matcher:
@@ -140,7 +180,7 @@ packages:
     description:
       name: matcher
       sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.17"
   material_color_utilities:
@@ -148,23 +188,23 @@ packages:
     description:
       name: material_color_utilities
       sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   path:
@@ -172,7 +212,7 @@ packages:
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   plugin_platform_interface:
@@ -180,7 +220,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
   resizable_widget:
@@ -188,9 +228,25 @@ packages:
     description:
       name: resizable_widget
       sha256: db2919754b93f386b9b3fb15e9f48f6c9d6d41f00a24397629133c99df86606a
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  riverpod_annotation:
+    dependency: transitive
+    description:
+      name: riverpod_annotation
+      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -201,7 +257,7 @@ packages:
     description:
       name: source_span
       sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
   stack_trace:
@@ -209,15 +265,23 @@ packages:
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   string_scanner:
@@ -225,7 +289,7 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   term_glyph:
@@ -233,87 +297,95 @@ packages:
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   url_launcher:
     dependency: transitive
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "5c8b6c2d89a78f5a1cca70a73d9d5f86c701b36b42f9c9dac7bad592113c28e9"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.3.24"
+    version: "6.3.28"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "6b63f1441e4f653ae799166a72b50b1767321ecc263a57aadf825a7a2a5477d9"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
     source: hosted
-    version: "6.3.5"
+    version: "6.3.6"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      sha256: "8262208506252a3ed4ff5c0dc1e973d2c0e0ef337d0a074d35634da5d44397c9"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   vm_service:
@@ -321,7 +393,7 @@ packages:
     description:
       name: vm_service
       sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "15.0.2"
   web:
@@ -329,25 +401,25 @@ packages:
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   widgetbook:
     dependency: "direct main"
     description:
       name: widgetbook
-      sha256: "50d996b09fe5094f6cbd8648628b6fbf5e35b64932afe52c6e7ebf9e2411b9cd"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      sha256: "0ffadb039b1811870b2f643e1730d419d38435b0e1931cc83f32ecd7e50200e4"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.20.0"
+    version: "3.20.2"
   widgetbook_annotation:
     dependency: transitive
     description:
       name: widgetbook_annotation
       sha256: "55504431b15eedef3c1fc4af2d108ac98b32610b59d4a4e2eea87a8515d17eef"
-      url: "https://jfrog.int.bourso.net/artifactory/api/pub/web-v-pub/"
+      url: "https://pub.dev"
     source: hosted
     version: "3.9.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/lib/flutterish.dart
+++ b/lib/flutterish.dart
@@ -4,3 +4,10 @@ library;
 export 'src/stepper/stepper.dart';
 export 'src/stepper/stepper_step.dart';
 export 'src/stepper/stepper_theme.dart';
+
+// Admin Architecture
+export 'src/flutterish_admin.dart';
+export 'src/core/interfaces/data_provider.dart';
+export 'src/core/interfaces/auth_provider.dart';
+export 'src/core/interfaces/schema_provider.dart';
+export 'src/core/schema/schema_models.dart';

--- a/lib/src/components/field/text_field.dart
+++ b/lib/src/components/field/text_field.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/state/record_state.dart';
+import '../../core/schema/schema_models.dart';
+
+class TextFieldComponent extends ConsumerWidget {
+  final String source;
+
+  const TextFieldComponent({super.key, required this.source});
+
+  static Widget builder(ComponentConfig config, List<Widget> children) {
+    return TextFieldComponent(source: config.props['source'] ?? '');
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final record = ref.watch(recordProvider);
+    final value = record[source];
+    return Text(value?.toString() ?? '');
+  }
+}

--- a/lib/src/components/grid/datagrid.dart
+++ b/lib/src/components/grid/datagrid.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/state/list_state.dart';
+import '../../core/state/record_state.dart';
+import '../../core/schema/schema_models.dart';
+
+class Datagrid extends ConsumerWidget {
+  final ComponentConfig config;
+  final List<Widget> children;
+
+  const Datagrid({super.key, required this.config, required this.children});
+
+  static Widget builder(ComponentConfig config, List<Widget> children) {
+    return Datagrid(config: config, children: children);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // We expect listContextResultProvider to be available (provided by ListView)
+    final listResult = ref.watch(listContextResultProvider);
+
+    // Derive columns from children config
+    // This assumes that the 'children' widgets correspond 1-to-1 with config.children
+    final columns = config.children.map((childConfig) {
+      final label = childConfig.props['label'] ?? childConfig.props['source'] ?? '';
+      return DataColumn(label: Text(label.toString()));
+    }).toList();
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.vertical,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: DataTable(
+          columns: columns,
+          rows: listResult.data.map((record) {
+            return DataRow(
+              cells: children.map((colWidget) {
+                return DataCell(
+                  ProviderScope(
+                    overrides: [
+                      recordProvider.overrideWithValue(record),
+                    ],
+                    child: colWidget,
+                  ),
+                );
+              }).toList(),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/components/list/list_view.dart
+++ b/lib/src/components/list/list_view.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/state/resource_state.dart';
+import '../../core/state/list_state.dart';
+
+class ListViewComponent extends ConsumerWidget {
+  final List<Widget> children;
+  final String title;
+
+  const ListViewComponent({super.key, required this.children, this.title = ''});
+
+  static Widget builder(ComponentConfig config, List<Widget> children) {
+    return ListViewComponent(
+      title: config.props['title'] ?? '',
+      children: children,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final resource = ref.watch(currentResourceProvider);
+    final listDataAsync = ref.watch(listDataProvider(resource));
+
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (title.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16.0),
+              child: Text(title, style: Theme.of(context).textTheme.headlineMedium),
+            ),
+          Expanded(
+            child: listDataAsync.when(
+              data: (data) => ProviderScope(
+                overrides: [
+                  listContextResultProvider.overrideWithValue(data),
+                ],
+                child: children.isNotEmpty
+                    ? children.first
+                    : const Center(child: Text('No list component (e.g. Datagrid) defined')),
+              ),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (err, stack) => Center(child: Text('Error loading data: $err')),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/core/engine/component_registry.dart
+++ b/lib/src/core/engine/component_registry.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/widgets.dart';
+import '../schema/schema_models.dart';
+
+/// Function signature for building a component from config and children widgets.
+typedef ComponentBuilder = Widget Function(ComponentConfig config, List<Widget> children);
+
+/// Singleton registry for mapping JSON component types to Flutter widgets.
+class ComponentRegistry {
+  static final ComponentRegistry _instance = ComponentRegistry._internal();
+  factory ComponentRegistry() => _instance;
+  ComponentRegistry._internal();
+
+  final Map<String, ComponentBuilder> _builders = {};
+
+  /// Register a component builder for a specific type.
+  void register(String type, ComponentBuilder builder) {
+    _builders[type] = builder;
+  }
+
+  /// Build a widget instance from config and children.
+  Widget build(ComponentConfig config, List<Widget> children) {
+    final builder = _builders[config.type];
+    if (builder == null) {
+      return Container(
+        padding: const EdgeInsets.all(8),
+        color: const Color(0xFFFFEBEE),
+        child: Text(
+          'Unknown component: ${config.type}',
+          style: const TextStyle(color: Color(0xFFB71C1C)),
+        ),
+      );
+    }
+    return builder(config, children);
+  }
+}

--- a/lib/src/core/engine/default_components.dart
+++ b/lib/src/core/engine/default_components.dart
@@ -1,0 +1,11 @@
+import 'component_registry.dart';
+import '../../components/list/list_view.dart';
+import '../../components/grid/datagrid.dart';
+import '../../components/field/text_field.dart';
+
+/// Registers the default components available in the framework.
+void registerDefaultComponents() {
+  ComponentRegistry().register('List', ListViewComponent.builder);
+  ComponentRegistry().register('Datagrid', Datagrid.builder);
+  ComponentRegistry().register('TextField', TextFieldComponent.builder);
+}

--- a/lib/src/core/engine/sdui_builder.dart
+++ b/lib/src/core/engine/sdui_builder.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import '../schema/schema_models.dart';
+import 'component_registry.dart';
+
+/// A widget that builds a UI subtree from a ComponentConfig.
+class SduiBuilder extends StatelessWidget {
+  final ComponentConfig config;
+
+  const SduiBuilder({super.key, required this.config});
+
+  @override
+  Widget build(BuildContext context) {
+    // Recursively build children
+    final children = config.children.map((childConfig) {
+      return SduiBuilder(config: childConfig);
+    }).toList();
+
+    // Delegate to registry to find the Flutter widget
+    return ComponentRegistry().build(config, children);
+  }
+}

--- a/lib/src/core/interfaces/auth_provider.dart
+++ b/lib/src/core/interfaces/auth_provider.dart
@@ -1,0 +1,20 @@
+
+/// The interface for handling authentication.
+/// Mimics React-Admin's AuthProvider.
+abstract class AuthProvider {
+  /// Log the user in.
+  Future<void> login(Map<String, dynamic> params);
+
+  /// Log the user out.
+  Future<void> logout();
+
+  /// Check if the user is authenticated.
+  /// Should throw if not authenticated.
+  Future<void> checkAuth();
+
+  /// Check if an error implies an authentication error (e.g. 401).
+  Future<void> checkError(dynamic error);
+
+  /// Get the permissions of the current user.
+  Future<dynamic> getPermissions();
+}

--- a/lib/src/core/interfaces/data_provider.dart
+++ b/lib/src/core/interfaces/data_provider.dart
@@ -1,0 +1,33 @@
+
+/// Result of a getList call
+class GetListResult {
+  final List<Map<String, dynamic>> data;
+  final int total;
+
+  GetListResult({required this.data, required this.total});
+}
+
+/// The interface for fetching data.
+/// Mimics React-Admin's DataProvider.
+abstract class DataProvider {
+  /// Get a list of resources.
+  Future<GetListResult> getList(
+    String resource, {
+    int page = 1,
+    int perPage = 10,
+    Map<String, dynamic>? filter,
+    Map<String, dynamic>? sort,
+  });
+
+  /// Get a single resource by ID.
+  Future<Map<String, dynamic>> getOne(String resource, String id);
+
+  /// Update a resource.
+  Future<Map<String, dynamic>> update(String resource, String id, Map<String, dynamic> data);
+
+  /// Create a new resource.
+  Future<Map<String, dynamic>> create(String resource, Map<String, dynamic> data);
+
+  /// Delete a resource.
+  Future<void> delete(String resource, String id);
+}

--- a/lib/src/core/interfaces/schema_provider.dart
+++ b/lib/src/core/interfaces/schema_provider.dart
@@ -1,0 +1,6 @@
+
+/// Interface for fetching the UI configuration (Schema).
+abstract class SchemaProvider {
+  /// Fetches the global application schema (resources, layout, etc.)
+  Future<Map<String, dynamic>> getSchema();
+}

--- a/lib/src/core/schema/schema_models.dart
+++ b/lib/src/core/schema/schema_models.dart
@@ -1,0 +1,39 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'schema_models.freezed.dart';
+part 'schema_models.g.dart';
+
+@freezed
+class AdminConfig with _$AdminConfig {
+  const factory AdminConfig({
+    @Default('Admin') String title,
+    @Default([]) List<ResourceConfig> resources,
+    @Default('Layout') String layout,
+  }) = _AdminConfig;
+
+  factory AdminConfig.fromJson(Map<String, dynamic> json) => _$AdminConfigFromJson(json);
+}
+
+@freezed
+class ResourceConfig with _$ResourceConfig {
+  const factory ResourceConfig({
+    required String name,
+    ComponentConfig? list,
+    ComponentConfig? edit,
+    ComponentConfig? create,
+    ComponentConfig? show,
+  }) = _ResourceConfig;
+
+  factory ResourceConfig.fromJson(Map<String, dynamic> json) => _$ResourceConfigFromJson(json);
+}
+
+@freezed
+class ComponentConfig with _$ComponentConfig {
+  const factory ComponentConfig({
+    required String type,
+    @Default({}) Map<String, dynamic> props,
+    @Default([]) List<ComponentConfig> children,
+  }) = _ComponentConfig;
+
+  factory ComponentConfig.fromJson(Map<String, dynamic> json) => _$ComponentConfigFromJson(json);
+}

--- a/lib/src/core/schema/schema_models.freezed.dart
+++ b/lib/src/core/schema/schema_models.freezed.dart
@@ -1,0 +1,769 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'schema_models.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+  'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models',
+);
+
+AdminConfig _$AdminConfigFromJson(Map<String, dynamic> json) {
+  return _AdminConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AdminConfig {
+  String get title => throw _privateConstructorUsedError;
+  List<ResourceConfig> get resources => throw _privateConstructorUsedError;
+  String get layout => throw _privateConstructorUsedError;
+
+  /// Serializes this AdminConfig to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AdminConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AdminConfigCopyWith<AdminConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AdminConfigCopyWith<$Res> {
+  factory $AdminConfigCopyWith(
+    AdminConfig value,
+    $Res Function(AdminConfig) then,
+  ) = _$AdminConfigCopyWithImpl<$Res, AdminConfig>;
+  @useResult
+  $Res call({String title, List<ResourceConfig> resources, String layout});
+}
+
+/// @nodoc
+class _$AdminConfigCopyWithImpl<$Res, $Val extends AdminConfig>
+    implements $AdminConfigCopyWith<$Res> {
+  _$AdminConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AdminConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = null,
+    Object? resources = null,
+    Object? layout = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            title: null == title
+                ? _value.title
+                : title // ignore: cast_nullable_to_non_nullable
+                      as String,
+            resources: null == resources
+                ? _value.resources
+                : resources // ignore: cast_nullable_to_non_nullable
+                      as List<ResourceConfig>,
+            layout: null == layout
+                ? _value.layout
+                : layout // ignore: cast_nullable_to_non_nullable
+                      as String,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$AdminConfigImplCopyWith<$Res>
+    implements $AdminConfigCopyWith<$Res> {
+  factory _$$AdminConfigImplCopyWith(
+    _$AdminConfigImpl value,
+    $Res Function(_$AdminConfigImpl) then,
+  ) = __$$AdminConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String title, List<ResourceConfig> resources, String layout});
+}
+
+/// @nodoc
+class __$$AdminConfigImplCopyWithImpl<$Res>
+    extends _$AdminConfigCopyWithImpl<$Res, _$AdminConfigImpl>
+    implements _$$AdminConfigImplCopyWith<$Res> {
+  __$$AdminConfigImplCopyWithImpl(
+    _$AdminConfigImpl _value,
+    $Res Function(_$AdminConfigImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of AdminConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? title = null,
+    Object? resources = null,
+    Object? layout = null,
+  }) {
+    return _then(
+      _$AdminConfigImpl(
+        title: null == title
+            ? _value.title
+            : title // ignore: cast_nullable_to_non_nullable
+                  as String,
+        resources: null == resources
+            ? _value._resources
+            : resources // ignore: cast_nullable_to_non_nullable
+                  as List<ResourceConfig>,
+        layout: null == layout
+            ? _value.layout
+            : layout // ignore: cast_nullable_to_non_nullable
+                  as String,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AdminConfigImpl implements _AdminConfig {
+  const _$AdminConfigImpl({
+    this.title = 'Admin',
+    final List<ResourceConfig> resources = const [],
+    this.layout = 'Layout',
+  }) : _resources = resources;
+
+  factory _$AdminConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AdminConfigImplFromJson(json);
+
+  @override
+  @JsonKey()
+  final String title;
+  final List<ResourceConfig> _resources;
+  @override
+  @JsonKey()
+  List<ResourceConfig> get resources {
+    if (_resources is EqualUnmodifiableListView) return _resources;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_resources);
+  }
+
+  @override
+  @JsonKey()
+  final String layout;
+
+  @override
+  String toString() {
+    return 'AdminConfig(title: $title, resources: $resources, layout: $layout)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AdminConfigImpl &&
+            (identical(other.title, title) || other.title == title) &&
+            const DeepCollectionEquality().equals(
+              other._resources,
+              _resources,
+            ) &&
+            (identical(other.layout, layout) || other.layout == layout));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    title,
+    const DeepCollectionEquality().hash(_resources),
+    layout,
+  );
+
+  /// Create a copy of AdminConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AdminConfigImplCopyWith<_$AdminConfigImpl> get copyWith =>
+      __$$AdminConfigImplCopyWithImpl<_$AdminConfigImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AdminConfigImplToJson(this);
+  }
+}
+
+abstract class _AdminConfig implements AdminConfig {
+  const factory _AdminConfig({
+    final String title,
+    final List<ResourceConfig> resources,
+    final String layout,
+  }) = _$AdminConfigImpl;
+
+  factory _AdminConfig.fromJson(Map<String, dynamic> json) =
+      _$AdminConfigImpl.fromJson;
+
+  @override
+  String get title;
+  @override
+  List<ResourceConfig> get resources;
+  @override
+  String get layout;
+
+  /// Create a copy of AdminConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AdminConfigImplCopyWith<_$AdminConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ResourceConfig _$ResourceConfigFromJson(Map<String, dynamic> json) {
+  return _ResourceConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ResourceConfig {
+  String get name => throw _privateConstructorUsedError;
+  ComponentConfig? get list => throw _privateConstructorUsedError;
+  ComponentConfig? get edit => throw _privateConstructorUsedError;
+  ComponentConfig? get create => throw _privateConstructorUsedError;
+  ComponentConfig? get show => throw _privateConstructorUsedError;
+
+  /// Serializes this ResourceConfig to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ResourceConfigCopyWith<ResourceConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ResourceConfigCopyWith<$Res> {
+  factory $ResourceConfigCopyWith(
+    ResourceConfig value,
+    $Res Function(ResourceConfig) then,
+  ) = _$ResourceConfigCopyWithImpl<$Res, ResourceConfig>;
+  @useResult
+  $Res call({
+    String name,
+    ComponentConfig? list,
+    ComponentConfig? edit,
+    ComponentConfig? create,
+    ComponentConfig? show,
+  });
+
+  $ComponentConfigCopyWith<$Res>? get list;
+  $ComponentConfigCopyWith<$Res>? get edit;
+  $ComponentConfigCopyWith<$Res>? get create;
+  $ComponentConfigCopyWith<$Res>? get show;
+}
+
+/// @nodoc
+class _$ResourceConfigCopyWithImpl<$Res, $Val extends ResourceConfig>
+    implements $ResourceConfigCopyWith<$Res> {
+  _$ResourceConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? list = freezed,
+    Object? edit = freezed,
+    Object? create = freezed,
+    Object? show = freezed,
+  }) {
+    return _then(
+      _value.copyWith(
+            name: null == name
+                ? _value.name
+                : name // ignore: cast_nullable_to_non_nullable
+                      as String,
+            list: freezed == list
+                ? _value.list
+                : list // ignore: cast_nullable_to_non_nullable
+                      as ComponentConfig?,
+            edit: freezed == edit
+                ? _value.edit
+                : edit // ignore: cast_nullable_to_non_nullable
+                      as ComponentConfig?,
+            create: freezed == create
+                ? _value.create
+                : create // ignore: cast_nullable_to_non_nullable
+                      as ComponentConfig?,
+            show: freezed == show
+                ? _value.show
+                : show // ignore: cast_nullable_to_non_nullable
+                      as ComponentConfig?,
+          )
+          as $Val,
+    );
+  }
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ComponentConfigCopyWith<$Res>? get list {
+    if (_value.list == null) {
+      return null;
+    }
+
+    return $ComponentConfigCopyWith<$Res>(_value.list!, (value) {
+      return _then(_value.copyWith(list: value) as $Val);
+    });
+  }
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ComponentConfigCopyWith<$Res>? get edit {
+    if (_value.edit == null) {
+      return null;
+    }
+
+    return $ComponentConfigCopyWith<$Res>(_value.edit!, (value) {
+      return _then(_value.copyWith(edit: value) as $Val);
+    });
+  }
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ComponentConfigCopyWith<$Res>? get create {
+    if (_value.create == null) {
+      return null;
+    }
+
+    return $ComponentConfigCopyWith<$Res>(_value.create!, (value) {
+      return _then(_value.copyWith(create: value) as $Val);
+    });
+  }
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ComponentConfigCopyWith<$Res>? get show {
+    if (_value.show == null) {
+      return null;
+    }
+
+    return $ComponentConfigCopyWith<$Res>(_value.show!, (value) {
+      return _then(_value.copyWith(show: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ResourceConfigImplCopyWith<$Res>
+    implements $ResourceConfigCopyWith<$Res> {
+  factory _$$ResourceConfigImplCopyWith(
+    _$ResourceConfigImpl value,
+    $Res Function(_$ResourceConfigImpl) then,
+  ) = __$$ResourceConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String name,
+    ComponentConfig? list,
+    ComponentConfig? edit,
+    ComponentConfig? create,
+    ComponentConfig? show,
+  });
+
+  @override
+  $ComponentConfigCopyWith<$Res>? get list;
+  @override
+  $ComponentConfigCopyWith<$Res>? get edit;
+  @override
+  $ComponentConfigCopyWith<$Res>? get create;
+  @override
+  $ComponentConfigCopyWith<$Res>? get show;
+}
+
+/// @nodoc
+class __$$ResourceConfigImplCopyWithImpl<$Res>
+    extends _$ResourceConfigCopyWithImpl<$Res, _$ResourceConfigImpl>
+    implements _$$ResourceConfigImplCopyWith<$Res> {
+  __$$ResourceConfigImplCopyWithImpl(
+    _$ResourceConfigImpl _value,
+    $Res Function(_$ResourceConfigImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? list = freezed,
+    Object? edit = freezed,
+    Object? create = freezed,
+    Object? show = freezed,
+  }) {
+    return _then(
+      _$ResourceConfigImpl(
+        name: null == name
+            ? _value.name
+            : name // ignore: cast_nullable_to_non_nullable
+                  as String,
+        list: freezed == list
+            ? _value.list
+            : list // ignore: cast_nullable_to_non_nullable
+                  as ComponentConfig?,
+        edit: freezed == edit
+            ? _value.edit
+            : edit // ignore: cast_nullable_to_non_nullable
+                  as ComponentConfig?,
+        create: freezed == create
+            ? _value.create
+            : create // ignore: cast_nullable_to_non_nullable
+                  as ComponentConfig?,
+        show: freezed == show
+            ? _value.show
+            : show // ignore: cast_nullable_to_non_nullable
+                  as ComponentConfig?,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ResourceConfigImpl implements _ResourceConfig {
+  const _$ResourceConfigImpl({
+    required this.name,
+    this.list,
+    this.edit,
+    this.create,
+    this.show,
+  });
+
+  factory _$ResourceConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ResourceConfigImplFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final ComponentConfig? list;
+  @override
+  final ComponentConfig? edit;
+  @override
+  final ComponentConfig? create;
+  @override
+  final ComponentConfig? show;
+
+  @override
+  String toString() {
+    return 'ResourceConfig(name: $name, list: $list, edit: $edit, create: $create, show: $show)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ResourceConfigImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.list, list) || other.list == list) &&
+            (identical(other.edit, edit) || other.edit == edit) &&
+            (identical(other.create, create) || other.create == create) &&
+            (identical(other.show, show) || other.show == show));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, list, edit, create, show);
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ResourceConfigImplCopyWith<_$ResourceConfigImpl> get copyWith =>
+      __$$ResourceConfigImplCopyWithImpl<_$ResourceConfigImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ResourceConfigImplToJson(this);
+  }
+}
+
+abstract class _ResourceConfig implements ResourceConfig {
+  const factory _ResourceConfig({
+    required final String name,
+    final ComponentConfig? list,
+    final ComponentConfig? edit,
+    final ComponentConfig? create,
+    final ComponentConfig? show,
+  }) = _$ResourceConfigImpl;
+
+  factory _ResourceConfig.fromJson(Map<String, dynamic> json) =
+      _$ResourceConfigImpl.fromJson;
+
+  @override
+  String get name;
+  @override
+  ComponentConfig? get list;
+  @override
+  ComponentConfig? get edit;
+  @override
+  ComponentConfig? get create;
+  @override
+  ComponentConfig? get show;
+
+  /// Create a copy of ResourceConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ResourceConfigImplCopyWith<_$ResourceConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+ComponentConfig _$ComponentConfigFromJson(Map<String, dynamic> json) {
+  return _ComponentConfig.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ComponentConfig {
+  String get type => throw _privateConstructorUsedError;
+  Map<String, dynamic> get props => throw _privateConstructorUsedError;
+  List<ComponentConfig> get children => throw _privateConstructorUsedError;
+
+  /// Serializes this ComponentConfig to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ComponentConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ComponentConfigCopyWith<ComponentConfig> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ComponentConfigCopyWith<$Res> {
+  factory $ComponentConfigCopyWith(
+    ComponentConfig value,
+    $Res Function(ComponentConfig) then,
+  ) = _$ComponentConfigCopyWithImpl<$Res, ComponentConfig>;
+  @useResult
+  $Res call({
+    String type,
+    Map<String, dynamic> props,
+    List<ComponentConfig> children,
+  });
+}
+
+/// @nodoc
+class _$ComponentConfigCopyWithImpl<$Res, $Val extends ComponentConfig>
+    implements $ComponentConfigCopyWith<$Res> {
+  _$ComponentConfigCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ComponentConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+    Object? props = null,
+    Object? children = null,
+  }) {
+    return _then(
+      _value.copyWith(
+            type: null == type
+                ? _value.type
+                : type // ignore: cast_nullable_to_non_nullable
+                      as String,
+            props: null == props
+                ? _value.props
+                : props // ignore: cast_nullable_to_non_nullable
+                      as Map<String, dynamic>,
+            children: null == children
+                ? _value.children
+                : children // ignore: cast_nullable_to_non_nullable
+                      as List<ComponentConfig>,
+          )
+          as $Val,
+    );
+  }
+}
+
+/// @nodoc
+abstract class _$$ComponentConfigImplCopyWith<$Res>
+    implements $ComponentConfigCopyWith<$Res> {
+  factory _$$ComponentConfigImplCopyWith(
+    _$ComponentConfigImpl value,
+    $Res Function(_$ComponentConfigImpl) then,
+  ) = __$$ComponentConfigImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({
+    String type,
+    Map<String, dynamic> props,
+    List<ComponentConfig> children,
+  });
+}
+
+/// @nodoc
+class __$$ComponentConfigImplCopyWithImpl<$Res>
+    extends _$ComponentConfigCopyWithImpl<$Res, _$ComponentConfigImpl>
+    implements _$$ComponentConfigImplCopyWith<$Res> {
+  __$$ComponentConfigImplCopyWithImpl(
+    _$ComponentConfigImpl _value,
+    $Res Function(_$ComponentConfigImpl) _then,
+  ) : super(_value, _then);
+
+  /// Create a copy of ComponentConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? type = null,
+    Object? props = null,
+    Object? children = null,
+  }) {
+    return _then(
+      _$ComponentConfigImpl(
+        type: null == type
+            ? _value.type
+            : type // ignore: cast_nullable_to_non_nullable
+                  as String,
+        props: null == props
+            ? _value._props
+            : props // ignore: cast_nullable_to_non_nullable
+                  as Map<String, dynamic>,
+        children: null == children
+            ? _value._children
+            : children // ignore: cast_nullable_to_non_nullable
+                  as List<ComponentConfig>,
+      ),
+    );
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ComponentConfigImpl implements _ComponentConfig {
+  const _$ComponentConfigImpl({
+    required this.type,
+    final Map<String, dynamic> props = const {},
+    final List<ComponentConfig> children = const [],
+  }) : _props = props,
+       _children = children;
+
+  factory _$ComponentConfigImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ComponentConfigImplFromJson(json);
+
+  @override
+  final String type;
+  final Map<String, dynamic> _props;
+  @override
+  @JsonKey()
+  Map<String, dynamic> get props {
+    if (_props is EqualUnmodifiableMapView) return _props;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_props);
+  }
+
+  final List<ComponentConfig> _children;
+  @override
+  @JsonKey()
+  List<ComponentConfig> get children {
+    if (_children is EqualUnmodifiableListView) return _children;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_children);
+  }
+
+  @override
+  String toString() {
+    return 'ComponentConfig(type: $type, props: $props, children: $children)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ComponentConfigImpl &&
+            (identical(other.type, type) || other.type == type) &&
+            const DeepCollectionEquality().equals(other._props, _props) &&
+            const DeepCollectionEquality().equals(other._children, _children));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+    runtimeType,
+    type,
+    const DeepCollectionEquality().hash(_props),
+    const DeepCollectionEquality().hash(_children),
+  );
+
+  /// Create a copy of ComponentConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ComponentConfigImplCopyWith<_$ComponentConfigImpl> get copyWith =>
+      __$$ComponentConfigImplCopyWithImpl<_$ComponentConfigImpl>(
+        this,
+        _$identity,
+      );
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ComponentConfigImplToJson(this);
+  }
+}
+
+abstract class _ComponentConfig implements ComponentConfig {
+  const factory _ComponentConfig({
+    required final String type,
+    final Map<String, dynamic> props,
+    final List<ComponentConfig> children,
+  }) = _$ComponentConfigImpl;
+
+  factory _ComponentConfig.fromJson(Map<String, dynamic> json) =
+      _$ComponentConfigImpl.fromJson;
+
+  @override
+  String get type;
+  @override
+  Map<String, dynamic> get props;
+  @override
+  List<ComponentConfig> get children;
+
+  /// Create a copy of ComponentConfig
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ComponentConfigImplCopyWith<_$ComponentConfigImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/core/schema/schema_models.g.dart
+++ b/lib/src/core/schema/schema_models.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'schema_models.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$AdminConfigImpl _$$AdminConfigImplFromJson(Map<String, dynamic> json) =>
+    _$AdminConfigImpl(
+      title: json['title'] as String? ?? 'Admin',
+      resources:
+          (json['resources'] as List<dynamic>?)
+              ?.map((e) => ResourceConfig.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      layout: json['layout'] as String? ?? 'Layout',
+    );
+
+Map<String, dynamic> _$$AdminConfigImplToJson(_$AdminConfigImpl instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'resources': instance.resources.map((e) => e.toJson()).toList(),
+      'layout': instance.layout,
+    };
+
+_$ResourceConfigImpl _$$ResourceConfigImplFromJson(Map<String, dynamic> json) =>
+    _$ResourceConfigImpl(
+      name: json['name'] as String,
+      list: json['list'] == null
+          ? null
+          : ComponentConfig.fromJson(json['list'] as Map<String, dynamic>),
+      edit: json['edit'] == null
+          ? null
+          : ComponentConfig.fromJson(json['edit'] as Map<String, dynamic>),
+      create: json['create'] == null
+          ? null
+          : ComponentConfig.fromJson(json['create'] as Map<String, dynamic>),
+      show: json['show'] == null
+          ? null
+          : ComponentConfig.fromJson(json['show'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$ResourceConfigImplToJson(
+  _$ResourceConfigImpl instance,
+) => <String, dynamic>{
+  'name': instance.name,
+  'list': instance.list?.toJson(),
+  'edit': instance.edit?.toJson(),
+  'create': instance.create?.toJson(),
+  'show': instance.show?.toJson(),
+};
+
+_$ComponentConfigImpl _$$ComponentConfigImplFromJson(
+  Map<String, dynamic> json,
+) => _$ComponentConfigImpl(
+  type: json['type'] as String,
+  props: json['props'] as Map<String, dynamic>? ?? const {},
+  children:
+      (json['children'] as List<dynamic>?)
+          ?.map((e) => ComponentConfig.fromJson(e as Map<String, dynamic>))
+          .toList() ??
+      const [],
+);
+
+Map<String, dynamic> _$$ComponentConfigImplToJson(
+  _$ComponentConfigImpl instance,
+) => <String, dynamic>{
+  'type': instance.type,
+  'props': instance.props,
+  'children': instance.children.map((e) => e.toJson()).toList(),
+};

--- a/lib/src/core/state/core_providers.dart
+++ b/lib/src/core/state/core_providers.dart
@@ -1,0 +1,29 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../interfaces/data_provider.dart';
+import '../interfaces/auth_provider.dart';
+import '../interfaces/schema_provider.dart';
+import '../schema/schema_models.dart';
+
+part 'core_providers.g.dart';
+
+@Riverpod(keepAlive: true)
+DataProvider dataProvider(DataProviderRef ref) {
+  throw UnimplementedError('dataProvider must be overridden');
+}
+
+@Riverpod(keepAlive: true)
+AuthProvider authProvider(AuthProviderRef ref) {
+  throw UnimplementedError('authProvider must be overridden');
+}
+
+@Riverpod(keepAlive: true)
+SchemaProvider schemaProvider(SchemaProviderRef ref) {
+  throw UnimplementedError('schemaProvider must be overridden');
+}
+
+@riverpod
+Future<AdminConfig> appSchema(AppSchemaRef ref) async {
+  final schemaLoader = ref.watch(schemaProviderProvider);
+  final json = await schemaLoader.getSchema();
+  return AdminConfig.fromJson(json);
+}

--- a/lib/src/core/state/core_providers.g.dart
+++ b/lib/src/core/state/core_providers.g.dart
@@ -1,0 +1,78 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'core_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$dataProviderHash() => r'221576cb62c947d26221dec4e26dbadcf13e0aa5';
+
+/// See also [dataProvider].
+@ProviderFor(dataProvider)
+final dataProviderProvider = Provider<DataProvider>.internal(
+  dataProvider,
+  name: r'dataProviderProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$dataProviderHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef DataProviderRef = ProviderRef<DataProvider>;
+String _$authProviderHash() => r'd8f411977f0ed01fa7ab53452e1c9f73f6abfcfc';
+
+/// See also [authProvider].
+@ProviderFor(authProvider)
+final authProviderProvider = Provider<AuthProvider>.internal(
+  authProvider,
+  name: r'authProviderProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$authProviderHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AuthProviderRef = ProviderRef<AuthProvider>;
+String _$schemaProviderHash() => r'40bf3564da235d43648e39bc809eb4c35ba1714a';
+
+/// See also [schemaProvider].
+@ProviderFor(schemaProvider)
+final schemaProviderProvider = Provider<SchemaProvider>.internal(
+  schemaProvider,
+  name: r'schemaProviderProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$schemaProviderHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef SchemaProviderRef = ProviderRef<SchemaProvider>;
+String _$appSchemaHash() => r'90697a6116bc4d3921fe5f1883f200d93dcfd008';
+
+/// See also [appSchema].
+@ProviderFor(appSchema)
+final appSchemaProvider = AutoDisposeFutureProvider<AdminConfig>.internal(
+  appSchema,
+  name: r'appSchemaProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$appSchemaHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef AppSchemaRef = AutoDisposeFutureProviderRef<AdminConfig>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/core/state/list_state.dart
+++ b/lib/src/core/state/list_state.dart
@@ -1,0 +1,17 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../interfaces/data_provider.dart';
+import 'core_providers.dart';
+
+part 'list_state.g.dart';
+
+@riverpod
+Future<GetListResult> listData(ListDataRef ref, String resource) {
+  final dataProvider = ref.watch(dataProviderProvider);
+  return dataProvider.getList(resource);
+}
+
+// Provider to pass the result down to children (Datagrid)
+@riverpod
+GetListResult listContextResult(ListContextResultRef ref) {
+  throw UnimplementedError('No list context available');
+}

--- a/lib/src/core/state/record_state.dart
+++ b/lib/src/core/state/record_state.dart
@@ -1,0 +1,9 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'record_state.g.dart';
+
+/// Provides the current record data (e.g. inside a Datagrid row).
+@riverpod
+Map<String, dynamic> record(RecordRef ref) {
+  throw UnimplementedError('No record context found');
+}

--- a/lib/src/core/state/resource_state.dart
+++ b/lib/src/core/state/resource_state.dart
@@ -1,0 +1,9 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'resource_state.g.dart';
+
+/// Provides the name of the resource currently being viewed/edited.
+@riverpod
+String currentResource(CurrentResourceRef ref) {
+  throw UnimplementedError('No resource context found');
+}

--- a/lib/src/core/state/resource_state.g.dart
+++ b/lib/src/core/state/resource_state.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'resource_state.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$currentResourceHash() => r'8b67e2045d4225f929e67c435d89210d5da955c8';
+
+/// Provides the name of the resource currently being viewed/edited.
+///
+/// Copied from [currentResource].
+@ProviderFor(currentResource)
+final currentResourceProvider = AutoDisposeProvider<String>.internal(
+  currentResource,
+  name: r'currentResourceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$currentResourceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef CurrentResourceRef = AutoDisposeProviderRef<String>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/core/state/ui_state.dart
+++ b/lib/src/core/state/ui_state.dart
@@ -1,0 +1,11 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'ui_state.g.dart';
+
+@riverpod
+class SelectedResourceIndex extends _$SelectedResourceIndex {
+  @override
+  int build() => 0;
+
+  void set(int index) => state = index;
+}

--- a/lib/src/core/state/ui_state.g.dart
+++ b/lib/src/core/state/ui_state.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ui_state.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$selectedResourceIndexHash() =>
+    r'834caf8c8eb321ad6d0b0c952f31358fc5e3370c';
+
+/// See also [SelectedResourceIndex].
+@ProviderFor(SelectedResourceIndex)
+final selectedResourceIndexProvider =
+    AutoDisposeNotifierProvider<SelectedResourceIndex, int>.internal(
+      SelectedResourceIndex.new,
+      name: r'selectedResourceIndexProvider',
+      debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+          ? null
+          : _$selectedResourceIndexHash,
+      dependencies: null,
+      allTransitiveDependencies: null,
+    );
+
+typedef _$SelectedResourceIndex = AutoDisposeNotifier<int>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/src/flutterish_admin.dart
+++ b/lib/src/flutterish_admin.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'core/interfaces/data_provider.dart';
+import 'core/interfaces/auth_provider.dart';
+import 'core/interfaces/schema_provider.dart';
+import 'core/state/core_providers.dart';
+import 'core/engine/default_components.dart';
+import 'ui/layout/admin_scaffold.dart';
+
+/// The main entry point for a Flutterish Admin application.
+///
+/// It initializes the providers and loads the configuration.
+class FlutterishAdmin extends StatelessWidget {
+  final DataProvider dataProvider;
+  final AuthProvider authProvider;
+  final SchemaProvider schemaProvider;
+  final String title;
+
+  FlutterishAdmin({
+    super.key,
+    required this.dataProvider,
+    required this.authProvider,
+    required this.schemaProvider,
+    this.title = 'Admin',
+  }) {
+    registerDefaultComponents();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // We wrap everything in a ProviderScope to inject our dependencies.
+    // Note: If the user already wraps the app in a ProviderScope, this creates a nested scope,
+    // which is valid but we should be aware. For a library, this is usually safest.
+    return ProviderScope(
+      overrides: [
+        dataProviderProvider.overrideWithValue(dataProvider),
+        authProviderProvider.overrideWithValue(authProvider),
+        schemaProviderProvider.overrideWithValue(schemaProvider),
+      ],
+      child: const _AdminApp(),
+    );
+  }
+}
+
+class _AdminApp extends ConsumerWidget {
+  const _AdminApp();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final schemaAsync = ref.watch(appSchemaProvider);
+
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Admin',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: Colors.indigo,
+      ),
+      home: schemaAsync.when(
+        data: (schema) => AdminScaffold(config: schema),
+        loading: () => const Scaffold(body: Center(child: CircularProgressIndicator())),
+        error: (err, stack) => Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.error_outline, color: Colors.red, size: 48),
+                const SizedBox(height: 16),
+                Text('Failed to load admin configuration', style: Theme.of(context).textTheme.titleLarge),
+                const SizedBox(height: 8),
+                Text(err.toString(), style: Theme.of(context).textTheme.bodyMedium),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/layout/admin_scaffold.dart
+++ b/lib/src/ui/layout/admin_scaffold.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/schema/schema_models.dart';
+import '../../core/state/ui_state.dart';
+import '../../core/state/resource_state.dart';
+import '../../core/engine/sdui_builder.dart';
+
+class AdminScaffold extends ConsumerWidget {
+  final AdminConfig config;
+
+  const AdminScaffold({super.key, required this.config});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedIndex = ref.watch(selectedResourceIndexProvider);
+    final resources = config.resources;
+    final currentResource = resources.isNotEmpty && selectedIndex < resources.length
+        ? resources[selectedIndex]
+        : null;
+
+    return Scaffold(
+      appBar: AppBar(title: Text(config.title)),
+      body: Row(
+        children: [
+          NavigationRail(
+            selectedIndex: selectedIndex,
+            onDestinationSelected: (int index) {
+              ref.read(selectedResourceIndexProvider.notifier).set(index);
+            },
+            labelType: NavigationRailLabelType.all,
+            destinations: resources.map((r) => NavigationRailDestination(
+              icon: const Icon(Icons.folder_open),
+              selectedIcon: const Icon(Icons.folder),
+              label: Text(r.name)
+            )).toList(),
+          ),
+          const VerticalDivider(thickness: 1, width: 1),
+          Expanded(
+            child: currentResource != null
+                ? _ResourceView(resource: currentResource)
+                : const Center(child: Text('No resources defined')),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ResourceView extends StatelessWidget {
+  final ResourceConfig resource;
+
+  const _ResourceView({required this.resource});
+
+  @override
+  Widget build(BuildContext context) {
+    final listConfig = resource.list;
+    if (listConfig == null) {
+      return const Center(child: Text('No list view defined for this resource'));
+    }
+
+    return ProviderScope(
+      overrides: [
+        currentResourceProvider.overrideWithValue(resource.name),
+      ],
+      child: SduiBuilder(config: listConfig),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,45 +9,19 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_riverpod: ^2.6.1
+  riverpod_annotation: ^2.6.1
+  json_annotation: ^4.9.0
+  freezed_annotation: ^2.4.1
+  http: ^1.2.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.8
+  riverpod_generator: ^2.6.3
+  json_serializable: ^6.9.0
+  freezed: ^2.4.7
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter packages.
 flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/to/asset-from-package
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/to/font-from-package

--- a/test/sdui_test.dart
+++ b/test/sdui_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterish/src/core/engine/component_registry.dart';
+import 'package:flutterish/src/core/schema/schema_models.dart';
+
+void main() {
+  group('SDUI Engine Tests', () {
+    testWidgets('ComponentRegistry builds registered component', (tester) async {
+      final registry = ComponentRegistry();
+      // Clear registry first if it's singleton? Ideally we should make it mockable or resetable.
+      // Since it's a singleton, we just overwrite 'TestBox' if it exists.
+      registry.register('TestBox', (config, children) => Container(key: const Key('box')));
+
+      final config = const ComponentConfig(type: 'TestBox');
+
+      await tester.pumpWidget(registry.build(config, []));
+
+      expect(find.byKey(const Key('box')), findsOneWidget);
+    });
+
+    testWidgets('ComponentRegistry handles unknown component', (tester) async {
+      final registry = ComponentRegistry();
+      final config = const ComponentConfig(type: 'UnknownComponentXYZ');
+
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: registry.build(config, [])
+      ));
+
+      expect(find.text('Unknown component: UnknownComponentXYZ'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces a major architectural update to transform `flutterish` into a Server-Driven UI (SDUI) framework compliant with React-Admin concepts.

Key changes:
1.  **Core Interfaces**: Defined `DataProvider`, `AuthProvider`, and `SchemaProvider` to mirror React-Admin's data layer.
2.  **SDUI Engine**: Implemented `ComponentRegistry` to map JSON types to widgets and `SduiBuilder` for recursive rendering.
3.  **State Management**: Integrated `flutter_riverpod` for handling global and scoped state (Resource, List, Record contexts).
4.  **Components**: Added basic implementations of `ListView`, `Datagrid`, and `TextField`.
5.  **Documentation**: Added `ARCHITECTURE.md` explaining the new design.
6.  **Example**: Updated the example app to show a functional admin dashboard driven by a mock JSON schema.

This lays the foundation for building fully dynamic admin interfaces in Flutter.

---
*PR created automatically by Jules for task [12564375546225992929](https://jules.google.com/task/12564375546225992929) started by @evaisse*